### PR TITLE
Fix spotless plugin implicit dependency warning with Gradle 7

### DIFF
--- a/gradle/spotless.gradle
+++ b/gradle/spotless.gradle
@@ -9,27 +9,13 @@ apply plugin: 'groovy'
 
 spotless {
     groovyGradle {
-        target fileTree(rootDir) {
-            include "**/*.gradle"
-        }
+        target "**/*.gradle"
         greclipse()
         indentWithSpaces()
     }
 
-    java {
-        target fileTree(rootDir) {
-            include '**/*.java'
-            exclude "**/build/*"
-        }
-
-        googleJavaFormat().aosp()
-    }
-
     kotlin {
-        target fileTree(rootDir) {
-            include '**/*.kt'
-            exclude '**/build/*'
-        }
+        target "**/*.kt"
 
         ktlint(rootProject.ktlint_version)
                 .userData([


### PR DESCRIPTION
Description & Context
=====================
Before:

```
  - Gradle detected a problem with the following location: '/home/runner/work/bartender-android/bartender-android/build/spotless/spotlessKotlin'. Reason: Task ':spotlessGroovyGradle' uses this output of task ':spotlessKotlin' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.0.2/userguide/validation_problems.html#implicit_dependency for more details about this problem.
```

Related Links
-------------

Testing Done
------------